### PR TITLE
removed overwriting of cfg

### DIFF
--- a/dreamer_pretrain.py
+++ b/dreamer_pretrain.py
@@ -290,8 +290,6 @@ class Workspace:
 def main(cfg):
     from dreamer_pretrain import Workspace as W
     root_dir = Path.cwd()
-    cfg.use_wandb = False
-    cfg.project_name = 'local'
     workspace = W(cfg)
     workspace.root_dir = root_dir
     snapshot = workspace.root_dir / 'last_snapshot.pt'


### PR DESCRIPTION
in `main` of dreamer_pretrain.py, there is hardcoded project name and `use_wandb=False`. I think it is better if values from dreamer_pretrain.yaml are used.

(thanks for nice repository :)